### PR TITLE
chore(security): automate docker monitor issue flow and release gate

### DIFF
--- a/.github/workflows/ci-heavy.yml
+++ b/.github/workflows/ci-heavy.yml
@@ -104,6 +104,7 @@ jobs:
           ignore-unfixed: true
           vuln-type: "os,library"
           severity: "CRITICAL,HIGH"
+          trivyignores: ".trivyignore.example"
 
   test-matrix:
     name: Test (Python ${{ matrix.python-version }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,16 +212,17 @@ jobs:
         run: docker build -t finbot:${{ github.sha }} .
 
       - name: Run Trivy vulnerability scanner on Dockerfile
-        uses: aquasecurity/trivy-action@97e0b3872f55f89b95b2f65b3dbab56962816478 # 0.29.0
+        uses: aquasecurity/trivy-action@97e0b3872f55f89b95b2f65b3dbab56962816478 # v0.34.1
         with:
           scan-type: 'config'
           scan-ref: 'Dockerfile'
           format: 'table'
           exit-code: '0'
           severity: 'CRITICAL,HIGH,MEDIUM,LOW'
+          trivyignores: '.trivyignore.example'
 
       - name: Run Trivy vulnerability scanner on image
-        uses: aquasecurity/trivy-action@97e0b3872f55f89b95b2f65b3dbab56962816478 # 0.29.0
+        uses: aquasecurity/trivy-action@97e0b3872f55f89b95b2f65b3dbab56962816478 # v0.34.1
         with:
           image-ref: 'finbot:${{ github.sha }}'
           format: 'sarif'
@@ -229,6 +230,7 @@ jobs:
           severity: 'CRITICAL,HIGH,MEDIUM,LOW'
           exit-code: '1'
           ignore-unfixed: true
+          trivyignores: '.trivyignore.example'
 
       - name: Upload Trivy results to GitHub Security tab
         if: always()
@@ -238,20 +240,22 @@ jobs:
 
       - name: Run Trivy vulnerability scanner for summary
         if: always()
-        uses: aquasecurity/trivy-action@97e0b3872f55f89b95b2f65b3dbab56962816478 # 0.29.0
+        uses: aquasecurity/trivy-action@97e0b3872f55f89b95b2f65b3dbab56962816478 # v0.34.1
         with:
           image-ref: 'finbot:${{ github.sha }}'
           format: 'table'
           severity: 'CRITICAL,HIGH,MEDIUM,LOW'
+          trivyignores: '.trivyignore.example'
 
       - name: Generate detailed security report
         if: always()
-        uses: aquasecurity/trivy-action@97e0b3872f55f89b95b2f65b3dbab56962816478 # 0.29.0
+        uses: aquasecurity/trivy-action@97e0b3872f55f89b95b2f65b3dbab56962816478 # v0.34.1
         with:
           image-ref: 'finbot:${{ github.sha }}'
           format: 'json'
           output: 'trivy-report.json'
           severity: 'CRITICAL,HIGH,MEDIUM,LOW'
+          trivyignores: '.trivyignore.example'
 
       - name: Upload security report
         if: always()

--- a/.github/workflows/docker-security-monitor.yml
+++ b/.github/workflows/docker-security-monitor.yml
@@ -1,0 +1,181 @@
+name: Docker Security Monitor
+
+on:
+  schedule:
+    # Weekly on Monday at 07:00 UTC
+    - cron: "0 7 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+  issues: write
+
+concurrency:
+  group: docker-security-monitor-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  monitor:
+    name: Scheduled Docker Security Scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Build Docker image
+        run: docker build -t finbot:security-${{ github.sha }} .
+
+      - name: Run Trivy vulnerability scanner on image (SARIF)
+        uses: aquasecurity/trivy-action@97e0b3872f55f89b95b2f65b3dbab56962816478 # v0.34.1
+        with:
+          image-ref: "finbot:security-${{ github.sha }}"
+          format: "sarif"
+          output: "trivy-results.sarif"
+          severity: "CRITICAL,HIGH,MEDIUM,LOW"
+          exit-code: "0"
+          ignore-unfixed: true
+          trivyignores: ".trivyignore.example"
+
+      - name: Run Trivy vulnerability scanner on image (JSON)
+        uses: aquasecurity/trivy-action@97e0b3872f55f89b95b2f65b3dbab56962816478 # v0.34.1
+        with:
+          image-ref: "finbot:security-${{ github.sha }}"
+          format: "json"
+          output: "trivy-report.json"
+          severity: "CRITICAL,HIGH"
+          exit-code: "0"
+          ignore-unfixed: true
+          trivyignores: ".trivyignore.example"
+
+      - name: Summarize vulnerability counts
+        id: vuln_summary
+        run: |
+          set -euo pipefail
+
+          critical_count="$(jq '[.Results[]?.Vulnerabilities[]? | select(.Severity == "CRITICAL")] | length' trivy-report.json)"
+          high_count="$(jq '[.Results[]?.Vulnerabilities[]? | select(.Severity == "HIGH")] | length' trivy-report.json)"
+
+          echo "critical_count=${critical_count}" >> "$GITHUB_OUTPUT"
+          echo "high_count=${high_count}" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "### Scheduled Docker Security Summary"
+            echo "- Critical: ${critical_count}"
+            echo "- High: ${high_count}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload Trivy results to GitHub Security tab
+        if: always()
+        uses: github/codeql-action/upload-sarif@60d8f0d1f1f8c8d07ef53bd027032705d414ec28 # v3
+        with:
+          sarif_file: "trivy-results.sarif"
+
+      - name: Upload security artifacts
+        if: always()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: docker-security-monitor-report
+          path: |
+            trivy-results.sarif
+            trivy-report.json
+          retention-days: 30
+
+      - name: Fail when CRITICAL or HIGH vulnerabilities are present
+        env:
+          CRITICAL_COUNT: ${{ steps.vuln_summary.outputs.critical_count }}
+          HIGH_COUNT: ${{ steps.vuln_summary.outputs.high_count }}
+        run: |
+          set -euo pipefail
+          if (( CRITICAL_COUNT > 0 || HIGH_COUNT > 0 )); then
+            echo "Detected ${CRITICAL_COUNT} CRITICAL and ${HIGH_COUNT} HIGH vulnerabilities."
+            exit 1
+          fi
+
+      - name: Open or update Docker security issue on failure
+        if: failure()
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          CRITICAL_COUNT: ${{ steps.vuln_summary.outputs.critical_count || 'unknown' }}
+          HIGH_COUNT: ${{ steps.vuln_summary.outputs.high_count || 'unknown' }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          script: |
+            const title = "⚠️ Docker security scan detected HIGH/CRITICAL vulnerabilities";
+            const timestamp = new Date().toISOString();
+            const body = [
+              "Automated scheduled Docker security scan detected vulnerabilities.",
+              "",
+              `- Detected at: ${timestamp}`,
+              `- Critical: ${process.env.CRITICAL_COUNT}`,
+              `- High: ${process.env.HIGH_COUNT}`,
+              `- Workflow run: ${process.env.RUN_URL}`,
+              "",
+              "This issue is managed by workflow automation and is updated in place."
+            ].join("\n");
+
+            const requiredLabels = [
+              { name: "security", color: "b60205", description: "Security-related findings and hardening work" },
+              { name: "automated", color: "0e8a16", description: "Opened or updated by GitHub Actions" },
+              { name: "docker-security", color: "5319e7", description: "Container image vulnerability tracking" }
+            ];
+
+            for (const label of requiredLabels) {
+              try {
+                await github.rest.issues.getLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: label.name
+                });
+              } catch (error) {
+                if (error.status === 404) {
+                  await github.rest.issues.createLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    name: label.name,
+                    color: label.color,
+                    description: label.description
+                  });
+                } else {
+                  throw error;
+                }
+              }
+            }
+
+            const { data: openIssues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "open",
+              per_page: 100
+            });
+
+            const existing = openIssues.find((issue) => issue.title === title);
+            const labels = requiredLabels.map((label) => label.name);
+
+            if (existing) {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                title,
+                body,
+                labels
+              });
+
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                body: `Another failing scan was detected at ${timestamp}. Run: ${process.env.RUN_URL}`
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels
+              });
+            }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,27 @@ permissions:
   contents: write
 
 jobs:
+  docker-security-gate:
+    name: Docker Security Gate
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Build Docker image
+        run: docker build -t finbot:release-${{ github.sha }} .
+
+      - name: Block release on CRITICAL Docker vulnerabilities
+        uses: aquasecurity/trivy-action@97e0b3872f55f89b95b2f65b3dbab56962816478 # v0.34.1
+        with:
+          image-ref: 'finbot:release-${{ github.sha }}'
+          format: 'table'
+          severity: 'CRITICAL'
+          exit-code: '1'
+          ignore-unfixed: true
+          trivyignores: '.trivyignore.example'
+
   build:
     name: Build Distribution
     runs-on: ubuntu-latest
@@ -38,7 +59,7 @@ jobs:
   release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
-    needs: build
+    needs: [build, docker-security-gate]
 
     steps:
       - name: Checkout code

--- a/.trivyignore.example
+++ b/.trivyignore.example
@@ -1,25 +1,11 @@
-# Trivy Ignore File
-# This file allows you to ignore specific CVEs from security scans
-# Copy to .trivyignore and customize as needed
+# Trivy allowlist template for temporary vulnerability exceptions.
 #
-# Format: One CVE ID per line, with optional comments
-# Lines starting with # are comments
-
-# Example: Ignore a false positive
-# CVE-2024-12345
-
-# Example: Ignore while waiting for upstream fix
-# CVE-2024-67890
-# Rationale: Waiting for Python base image update, low exploitability
-# Tracked in: https://github.com/docker-library/python/issues/XXXX
-
-# Example: Ignore low-severity issue in build-only dependency
-# CVE-2024-11111
-# Rationale: Only affects build stage, not runtime image
-
-# Guidelines for adding ignores:
-# 1. Always include a rationale comment
-# 2. Link to upstream tracking issue if available
-# 3. Include severity level and affected package
-# 4. Set reminder to review (e.g., "Review by: 2026-03-01")
-# 5. Remove when fixed version is available
+# Process requirements for every ignored ID:
+# - Include the date added (YYYY-MM-DD)
+# - Include an expiry/review date (YYYY-MM-DD)
+# - Include a short justification
+#
+# Example:
+# CVE-2025-12345 # added:2026-03-02 expires:2026-06-02 reason:upstream package fix pending
+#
+# Keep this list minimal and time-bound.


### PR DESCRIPTION
## Summary
- add a new scheduled workflow: `.github/workflows/docker-security-monitor.yml`
  - runs weekly (Monday 07:00 UTC) and manually via workflow dispatch
  - builds the project image and scans with Trivy
  - uploads SARIF to GitHub Security tab and artifacts to workflow run
  - fails the job when CRITICAL or HIGH vulnerabilities are present
  - opens or updates a single tracking issue on failure
- add a release-time Docker security gate in `.github/workflows/release.yml`
  - blocks release publishing when CRITICAL vulnerabilities are detected
- wire existing Trivy scans to the tracked allowlist template `.trivyignore.example`
  - updated in `ci.yml` and `ci-heavy.yml`
- update `.trivyignore.example` with a stricter expiry/justification template

## Why
This keeps PR velocity high for a solo-dev flow while adding a reliable security control loop:
- non-blocking PR scan remains informational
- scheduled monitor creates persistent visibility and issue tracking
- release publishing is blocked on critical container risk

## Validation
- `uv run pre-commit run check-yaml --files .github/workflows/docker-security-monitor.yml .github/workflows/release.yml .github/workflows/ci.yml .github/workflows/ci-heavy.yml`
