### PR TITLE
fix(ci): add distinct SARIF categories to prevent duplicate upload rejection

### DIFF
--- a/.github/workflows/docker-security-monitor.yml
+++ b/.github/workflows/docker-security-monitor.yml
@@ -193,12 +193,14 @@ jobs:
         uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
         with:
           sarif_file: "trivy-results-cli.sarif"
+          category: "trivy-cli"
 
       - name: Upload API Trivy results to GitHub Security tab
         if: always() && steps.build_api_image.outcome == 'success'
         uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
         with:
           sarif_file: "trivy-results-api.sarif"
+          category: "trivy-api"
 
       - name: Upload security artifacts
         if: always()


### PR DESCRIPTION
## Summary
- Both `upload-sarif` steps used the same implicit category (`monitor/`) and tool (`Trivy`), causing GitHub to reject the second (API image) upload with: *"only one run of the codeql/analyze or codeql/upload-sarif actions is allowed per job per tool/category"*
- This failed the workflow job even when scans found 0 vulnerabilities, incorrectly reopening issue #32
- Fix: assign `category: trivy-cli` and `category: trivy-api` so each upload is a distinct code scanning result

Closes #32 (false positive — scan genuinely passed, Critical: 0, High: 0).

## Test plan
- [ ] Next scheduled Monday run should complete without reopening #32
- [ ] Both CLI and API SARIF results should appear separately in the Security tab