### PR TITLE
docs: record later-wave mkdocs posture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -409,6 +409,10 @@ make docs-build       # build static site
 uv run mkdocs gh-deploy  # deploy to GitHub Pages
 ```
 
+This is the current legacy-supported docs path. Keep Finbot on MkDocs 1.x here
+until the later shared migration wave proves safe `mkdocstrings` and
+`docs_site` parity.
+
 Source in `docs_site/` (index, user-guide, api, research, contributing, changelog). Project docs in `docs/` (adr, guidelines, planning, research, guides). See [ADR-003](docs/adr/ADR-003-add-mkdocs-documentation.md).
 
 ## CI/CD

--- a/docs/guidelines/documentation-guidelines.md
+++ b/docs/guidelines/documentation-guidelines.md
@@ -16,6 +16,11 @@ docs_site/          # MkDocs source for generated site
 notebooks/          # Jupyter notebooks with demos
 ```
 
+The docs site remains on MkDocs 1.x in the current wave. Do not start the
+Zensical migration here until the earlier shared waves succeed and separate
+API-doc parity checks prove that the `mkdocstrings` path and `docs_dir:
+docs_site` layout are both safe to migrate.
+
 ## When to Write Documentation
 
 | Change Type | Required Documentation |

--- a/docs/guides/github-pages-docs-deploy-runbook.md
+++ b/docs/guides/github-pages-docs-deploy-runbook.md
@@ -2,6 +2,10 @@
 
 This runbook verifies and maintains the Finbot MkDocs deployment path.
 
+It documents the current legacy-supported path only. Keep this repo on MkDocs
+1.x until the shared migration track reaches the later `mkdocstrings` /
+`docs_site` parity stage described in `docs/planning/roadmap.md`.
+
 ## Scope
 
 - Workflow: `.github/workflows/docs.yml`

--- a/docs/planning/roadmap.md
+++ b/docs/planning/roadmap.md
@@ -1,7 +1,7 @@
 # Finbot Roadmap
 
 **Created:** 2026-02-10
-**Last Updated:** 2026-04-10
+**Last Updated:** 2026-04-15
 **Status:** Priority 0-9 complete (1771 passing tests). P10 in progress.
 
 Improvements, fixes, and enhancements identified from comprehensive project evaluations. Organized by priority tier. Previous items (Priority 0-4) have been implemented. New Priority 5 items focus on making the project suitable for Ontario medical school admissions (OMSAS/CanMEDS frameworks).
@@ -76,6 +76,18 @@ See Completed Items table below and git history for details on implemented featu
 - [ ] End-to-end Playwright tests for all 12 pages
 - [ ] Responsive mobile testing and fixes
 - [ ] Production deployment configuration (Docker, env vars)
+
+## Priority 11: Documentation Platform Governance
+
+### P11.1 Cross-Repo Docs Platform Decision Track
+
+**Status:** IN PROGRESS (decision track only; no migration started)
+
+- [ ] Keep Finbot on MkDocs 1.x + Material in the short term and do not adopt MkDocs for net-new standalone docs work.
+- [ ] Continue pinning/locking MkDocs below v2 and keep the existing docs build healthy while the ecosystem decision remains open.
+- [ ] Keep Finbot out of the early migration waves; `qquotes`, `visitbrief`, and `waittimecanada` should prove the Zensical path first.
+- [ ] Treat Zensical as the intended MkDocs replacement only if strict/deploy behavior is solid and `mkdocstrings` support matures beyond its current preliminary state.
+- [ ] Re-evaluate Finbot only after the simpler sites have migrated successfully and separate API-doc parity checks pass. If Zensical stalls, use Sphinx + MyST as the mature fallback for any future standalone docs rebuild.
 
 ---
 

--- a/docs_site/README.md
+++ b/docs_site/README.md
@@ -1,6 +1,11 @@
 # Finbot Documentation Site
 
-This directory contains the source files for Finbot's MkDocs documentation site.
+This directory contains the source files for Finbot's current MkDocs 1.x
+documentation site.
+
+It is the live legacy-supported docs path for this repo. Do not treat it as
+the default for new standalone docs work while the shared migration track is
+still evaluating a later-wave replacement.
 
 ## Structure
 
@@ -51,7 +56,7 @@ uv run mkdocs build
 ### Deploy to GitHub Pages
 
 ```bash
-# Build and deploy (requires push access)
+# Build and deploy (requires push access; current legacy-supported path)
 uv run mkdocs gh-deploy
 ```
 


### PR DESCRIPTION
## What changed
- kept the existing MkDocs 1.x docs stack but made the later-wave posture explicit in active docs guidance
- updated AGENTS and the docs site README so the current `mkdocs gh-deploy` path is clearly marked as legacy-supported
- recorded the shared migration and fallback policy in the roadmap and docs runbook

## Why
Finbot depends on `mkdocstrings` and `docs_site` layout parity, so it should stay on the current stack until the later migration wave is actually safe.

## Validation
- `mkdocs build`
